### PR TITLE
Traducción NPCs de Lavender Town

### DIFF
--- a/data/maps/LavenderTown/text.inc
+++ b/data/maps/LavenderTown/text.inc
@@ -1,40 +1,41 @@
 LavenderTown_Text_DoYouBelieveInGhosts::
-    .string "Do you believe in ghosts?$"
+    .string "¿Crees en los fantasmas?$"
 
 LavenderTown_Text_SoThereAreBelievers::
-    .string "Really?\n"
-    .string "So there are believers…$"
+    .string "¿En serio?\n"
+    .string "Así que sí hay creyentes…$"
 
 LavenderTown_Text_JustImaginingWhiteHand::
-    .string "Hahaha, I guess not.\p"
-    .string "That white hand on your shoulder…\n"
-    .string "I'm just imagining it.$"
+    .string "Jajaja, supongo que no.\p"
+    .string "Esa mano blanca en tu hombro…\n"
+    .string "Sólo la estoy imaginando.$"
 
 LavenderTown_Text_TownKnownAsMonGraveSite::
-    .string "This town is known as the grave\n"
-    .string "site of POKéMON.\p"
-    .string "Memorial services are held in\n"
-    .string "POKéMON TOWER.$"
+    .string "Este pueblo es conocido como el\n"
+    .string "cementerio de los POKéMON.\p"
+    .string "Las ceremonias se realizan en la\n"
+    .string "TORRE POKéMON.$"
 
 LavenderTown_Text_GhostsAppearedInTower::
-    .string "Ghosts appeared in POKéMON TOWER.\p"
-    .string "I think they're the spirits of\n"
-    .string "POKéMON that the ROCKETS killed.$"
+    .string "Aparecieron fantasmas en la TORRE\n"
+    .string "POKéMON.\p"
+    .string "Creo que son los espíritus de los\n"
+    .string "POKéMON que los ROCKETS mataron.$"
 
 LavenderTown_Text_TownSign::
-    .string "LAVENDER TOWN\n"
-    .string "The Noble Purple Town$"
+    .string "PUEBLO LAVANDA\n"
+    .string "La noble ciudad púrpura$"
 
 LavenderTown_Text_SilphScopeNotice::
-    .string "New SILPH SCOPE!\n"
-    .string "Make the Invisible Plain to See!\p"
-    .string "SILPH CO.$"
+    .string "¡Nuevo VISOR SILPH!\n"
+    .string "¡Haz visible lo invisible!\p"
+    .string "SILPH S.A.$"
 
 LavenderTown_Text_VolunteerPokemonHouse::
-    .string "LAVENDER VOLUNTEER\n"
-    .string "POKéMON HOUSE$"
+    .string "CASA POKéMON VOLUNTARIA\n"
+    .string "DE LAVANDA$"
 
 LavenderTown_Text_PokemonTowerSign::
-    .string "POKéMON TOWER\n"
-    .string "Becalm the Spirits of POKéMON$"
+    .string "TORRE POKéMON\n"
+    .string "Calma a los espíritus POKéMON$"
 

--- a/data/maps/LavenderTown_House1/text.inc
+++ b/data/maps/LavenderTown_House1/text.inc
@@ -1,16 +1,16 @@
 LavenderTown_House1_Text_Cubone::
-    .string "CUBONE: Kyarugoo!$"
+    .string "CUBONE: ¡Kyarugoo!$"
 
 LavenderTown_House1_Text_RocketsKilledCubonesMother::
-    .string "Those horrible ROCKETS!\n"
-    .string "They deserve no mercy!\p"
-    .string "That poor CUBONE's mother…\p"
-    .string "It was killed trying to escape from\n"
+    .string "¡Esos horribles ROCKETS!\n"
+    .string "¡No merecen piedad!\p"
+    .string "La pobre madre de CUBONE...\p"
+    .string "La mataron al intentar escapar del\n"
     .string "TEAM ROCKET.$"
 
 LavenderTown_House1_Text_GhostOfPokemonTowerIsGone::
-    .string "The ghost of POKéMON TOWER is\n"
-    .string "gone!\p"
-    .string "Someone must have soothed its\n"
-    .string "restless spirit!$"
+    .string "¡El fantasma de la TORRE POKéMON\n"
+    .string "se fue!\p"
+    .string "¡Alguien debe haber calmado su\n"
+    .string "espíritu inquieto!$"
 

--- a/data/maps/LavenderTown_House2/text.inc
+++ b/data/maps/LavenderTown_House2/text.inc
@@ -1,47 +1,47 @@
 LavenderTown_House2_Text_WantMeToRateNicknames::
-    .string "Hello, hello!\n"
-    .string "I am the official NAME RATER!\p"
-    .string "Want me to rate the nicknames of\n"
-    .string "your POKéMON?$"
+    .string "¡Hola, hola!\n"
+    .string "¡Soy el EVALUADOR DE NOMBRES oficial!\p"
+    .string "¿Quieres que evalúe los apodos de\n"
+    .string "tus POKéMON?$"
 
 LavenderTown_House2_Text_CritiqueWhichMonsNickname::
-    .string "Which POKéMON's nickname should\n"
-    .string "I critique?$"
+    .string "¿El apodo de qué POKéMON\n"
+    .string "debo evaluar?$"
 
 LavenderTown_House2_Text_GiveItANicerName::
-    .string "{STR_VAR_1}, is it?\n"
-    .string "That is a decent nickname!\p"
-    .string "But, would you like me to give it\n"
-    .string "a nicer name?\p"
-    .string "How about it?$"
+    .string "{STR_VAR_1}, ¿eh?\n"
+    .string "¡Es un apodo decente!\p"
+    .string "Pero, ¿te gustaría que le diera\n"
+    .string "un nombre más bonito?\p"
+    .string "¿Qué dices?$"
 
 LavenderTown_House2_Text_WhatShallNewNicknameBe::
-    .string "Ah, good. Then, what shall the new\n"
-    .string "nickname be?$"
+    .string "Ah, bien. Entonces, ¿cuál será el\n"
+    .string "nuevo apodo?$"
 
 LavenderTown_House2_Text_FromNowOnShallBeKnownAsName::
-    .string "Done! From now on, this POKéMON\n"
-    .string "shall be known as {STR_VAR_1}!\p"
-    .string "It is a better name than before!\n"
-    .string "How fortunate for you!$"
+    .string "¡Listo! A partir de ahora, este\n"
+    .string "POKéMON se llamará {STR_VAR_1}!\p"
+    .string "¡Es un nombre mejor que antes!\n"
+    .string "¡Qué suerte tienes!$"
 
 LavenderTown_House2_Text_ISeeComeVisitAgain::
-    .string "I see.\n"
-    .string "Do come visit again.$"
+    .string "Ya veo.\n"
+    .string "Vuelve a visitarme.$"
 
 LavenderTown_House2_Text_FromNowOnShallBeKnownAsSameName::
-    .string "Done! From now on, this POKéMON\n"
-    .string "shall be known as {STR_VAR_1}!\p"
-    .string "It looks no different from before,\n"
-    .string "and yet, this is vastly superior!\p"
-    .string "How fortunate for you!$"
+    .string "¡Listo! A partir de ahora, este\n"
+    .string "POKéMON se llamará {STR_VAR_1}!\p"
+    .string "No parece diferente de antes,\n"
+    .string "¡y aun así, esto es mucho mejor!\p"
+    .string "¡Qué suerte tienes!$"
 
 LavenderTown_House2_Text_TrulyImpeccableName::
-    .string "{STR_VAR_1}, is it?\n"
-    .string "That is a truly impeccable name!\p"
-    .string "Take good care of {STR_VAR_1}!$"
+    .string "{STR_VAR_1}, ¿eh?\n"
+    .string "¡Ese es un nombre realmente impecable!\p"
+    .string "¡Cuida bien de {STR_VAR_1}!$"
 
 LavenderTown_House2_Text_ThatIsMerelyAnEgg::
-    .string "Now, now.\n"
-    .string "That is merely an EGG!$"
+    .string "Vamos, vamos.\n"
+    .string "¡Eso es sólo un HUEVO!$"
 

--- a/data/maps/LavenderTown_Mart/text.inc
+++ b/data/maps/LavenderTown_Mart/text.inc
@@ -1,25 +1,26 @@
 LavenderTown_Mart_Text_SearchingForStatRaiseItems::
-    .string "I'm searching for items that raise\n"
-    .string "the stats of POKéMON.\p"
-    .string "They're effective over the course\n"
-    .string "of a single battle.\p"
-    .string "X ATTACK, X DEFEND, X SPEED, \n"
-    .string "and X SPECIAL are what I'm after.\p"
-    .string "Do you know where I can get them?$"
+    .string "Estoy buscando objetos que aumenten\n"
+    .string "las estadísticas de los POKéMON.\p"
+    .string "Son efectivos durante un solo\n"
+    .string "combate.\p"
+    .string "X ATAQUE, X DEFENSA, X VELOCIDAD,\n"
+    .string "y X ESPECIAL son los que busco.\p"
+    .string "¿Sabes dónde puedo conseguirlos?$"
 
 LavenderTown_Mart_Text_DidYouBuyRevives::
-    .string "Did you buy some REVIVES?\n"
-    .string "They revive any fainted POKéMON!$"
+    .string "¿Compraste REVIVIR?\n"
+    .string "¡Reviven a cualquier POKéMON debilitado!$"
 
 LavenderTown_Mart_Text_TrainerDuosCanChallengeYou::
-    .string "Sometimes, a TRAINER duo will\n"
-    .string "challenge you with two POKéMON\l"
-    .string "at the same time.\p"
-    .string "If that happens, you have to send\n"
-    .string "out two POKéMON to battle, too.$"
+    .string "A veces, un dúo de ENTRENADORES\n"
+    .string "te desafiará con dos POKéMON\l"
+    .string "al mismo tiempo.\p"
+    .string "Si eso pasa, tú también debes\n"
+    .string "enviar dos POKéMON a combatir.$"
 
 LavenderTown_Mart_Text_SoldNuggetFromMountainsFor5000::
-    .string "この　あいだ　やまおくで\n"
-    .string "きんのたまを　ひろい　ましてね！\p"
-    .string "つかえない　しなもの　ですが\n"
-    .string "うったら　なんと　5000¥でした$"
+    .string "Hace poco, en lo profundo de\n"
+    .string "las montañas, encontré una PEPITA.\p"
+    .string "No sirve para nada, pero cuando\n"
+    .string "la vendí, ¡me dieron 5000¥!$"
+

--- a/data/maps/LavenderTown_PokemonCenter_1F/text.inc
+++ b/data/maps/LavenderTown_PokemonCenter_1F/text.inc
@@ -1,16 +1,16 @@
 LavenderTown_PokemonCenter_1F_Text_RocketsDoAnythingForMoney::
-    .string "TEAM ROCKET will do anything for\n"
-    .string "the sake of money!\p"
-    .string "There is no job too dirty, no deed\n"
-    .string "too heinous, no crime too wicked!$"
+    .string "¡El TEAM ROCKET hará cualquier cosa\n"
+    .string "por dinero!\p"
+    .string "No hay trabajo demasiado sucio, ni\n"
+    .string "acto tan atroz, ni crimen tan malvado!$"
 
 LavenderTown_PokemonCenter_1F_Text_CubonesMotherKilledByRockets::
-    .string "I saw CUBONE's mother trying to\n"
-    .string "escape from TEAM ROCKET.\p"
-    .string "She was killed trying to get away…$"
+    .string "Vi a la madre de CUBONE tratar de\n"
+    .string "escapar del TEAM ROCKET.\p"
+    .string "La mataron mientras intentaba huir…$"
 
 LavenderTown_PokemonCenter_1F_Text_PeoplePayForCuboneSkulls::
-    .string "You know how the CUBONE species\n"
-    .string "wears skulls, right?\p"
-    .string "People will pay a lot for one.$"
+    .string "¿Sabes que la especie CUBONE lleva\n"
+    .string "cráneos, verdad?\p"
+    .string "La gente pagaría mucho por uno.$"
 

--- a/data/maps/LavenderTown_VolunteerPokemonHouse/text.inc
+++ b/data/maps/LavenderTown_VolunteerPokemonHouse/text.inc
@@ -1,67 +1,70 @@
 LavenderTown_PokemonCenter_1F_Text_HearMrFujiNotFromAroundHere::
-    .string "I recently moved to this town.\p"
-    .string "I hear that MR. FUJI's not from\n"
-    .string "these parts originally, either.$"
+    .string "Me mudé a este pueblo hace poco.\p"
+    .string "Escuché que el SR. FUJI tampoco\n"
+    .string "es originario de aquí.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_WhereDidMrFujiGo::
-    .string "That's odd, MR. FUJI isn't here.\n"
-    .string "Where'd he go?$"
+    .string "Qué extraño, el SR. FUJI no está.\n"
+    .string "¿A dónde habrá ido?$"
 
 LavenderTown_VolunteerPokemonHouse_Text_MrFujiWasPrayingForCubonesMother::
-    .string "MR. FUJI had been praying alone\n"
-    .string "for CUBONE's mother.$"
+    .string "El SR. FUJI había estado rezando\n"
+    .string "solo por la madre de CUBONE.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_MrFujiLooksAfterOrphanedMons::
-    .string "This is really MR. FUJI's house.\p"
-    .string "He's really kind.\p"
-    .string "He looks after abandoned and\n"
-    .string "orphaned POKéMON.$"
+    .string "Esta es realmente la casa del SR.\n"
+    .string "FUJI.\p"
+    .string "Es muy amable.\p"
+    .string "Cuida de los POKéMON abandonados\n"
+    .string "y huérfanos.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_MonsNiceToHug::
-    .string "It's so warm!\n"
-    .string "POKéMON are so nice to hug.$"
+    .string "¡Es tan cálido!\n"
+    .string "Los POKéMON son tan agradables de\n"
+    .string "abrazar.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_Nidorino::
-    .string "NIDORINO: Gaoo!$"
+    .string "NIDORINO: ¡Gaoo!$"
 
 LavenderTown_VolunteerPokemonHouse_Text_Psyduck::
-    .string "PSYDUCK: Gwappa!$"
+    .string "PSYDUCK: ¡Gwappa!$"
 
 LavenderTown_VolunteerPokemonHouse_Text_IdLikeYouToHaveThis::
-    .string "MR. FUJI: {PLAYER}…\p"
-    .string "Your POKéDEX quest is one that\n"
-    .string "requires strong dedication.\p"
-    .string "Without deep love for POKéMON,\n"
-    .string "your quest may fail.\p"
-    .string "I'm not sure if this will help you,\n"
-    .string "but I'd like you to have it.$"
+    .string "SR. FUJI: {PLAYER}…\p"
+    .string "Tu misión de la POKéDEX requiere\n"
+    .string "una gran dedicación.\p"
+    .string "Sin un profundo amor por los\n"
+    .string "POKéMON, tu búsqueda puede fracasar.\p"
+    .string "No sé si esto te ayudará,\n"
+    .string "pero me gustaría que lo tuvieras.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_ReceivedPokeFluteFromMrFuji::
-    .string "{PLAYER} received a POKé FLUTE\n"
-    .string "from MR. FUJI.$"
+    .string "{PLAYER} recibió una FLAUTA POKé\n"
+    .string "del SR. FUJI.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_ExplainPokeFlute::
-    .string "Upon hearing the POKé FLUTE,\n"
-    .string "sleeping POKéMON will spring awake.\p"
-    .string "Try using it on POKéMON that are\n"
-    .string "sleeping obstacles.$"
+    .string "Al escuchar la FLAUTA POKé,\n"
+    .string "los POKéMON dormidos despertarán.\p"
+    .string "Intenta usarla en POKéMON que sean\n"
+    .string "obstáculos dormidos.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_MustMakeRoomForThis::
-    .string "You must make room for this!$"
+    .string "¡Debes hacer espacio para esto!$"
 
 LavenderTown_VolunteerPokemonHouse_Text_HasPokeFluteHelpedYou::
-    .string "MR. FUJI: Has my POKé FLUTE\n"
-    .string "helped you?$"
+    .string "SR. FUJI: ¿Te ha ayudado mi FLAUTA\n"
+    .string "POKé?$"
 
 LavenderTown_VolunteerPokemonHouse_Text_GrandPrizeDrawingClipped::
-    .string "POKéMON FAN MAGAZINE\n"
-    .string "Monthly Grand Prize Drawing!\p"
-    .string "The application form is…\p"
-    .string "Gone! It's been clipped out.\n"
-    .string "Someone must have applied already.$"
+    .string "REVISTA FAN DE POKéMON\n"
+    .string "¡Sorteo mensual del gran premio!\p"
+    .string "El formulario de inscripción…\p"
+    .string "¡No está! Fue recortado.\n"
+    .string "Seguro que alguien ya participó.$"
 
 LavenderTown_VolunteerPokemonHouse_Text_PokemonMagazinesLineShelf::
-    .string "POKéMON magazines line the shelf.\p"
+    .string "Hay revistas de POKéMON por todo\n"
+    .string "el estante.\p"
     .string "POKéMON INSIDER…\p"
     .string "POKéMON FAN…$"
 


### PR DESCRIPTION
## Summary
- Traduce los diálogos de Pueblo Lavanda al español latino neutro
- Actualiza textos del Centro Pokémon, Casas, Tienda y Casa Voluntaria

## Testing
- `make` *(falla: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895335be55c832ea9ad1838f3dbd16b