### PR TITLE
Add Geodude OBJ_EVENT definition

### DIFF
--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -157,6 +157,7 @@
 #define OBJ_EVENT_GFX_SS_ANNE 151
 #define OBJ_EVENT_GFX_SILVIO 156
 #define OBJ_EVENT_GFX_ZUBAT    158
+#define OBJ_EVENT_GFX_GEODUDE 159
 #define NUM_OBJ_EVENT_GFX      160
 
 // These are dynamic object gfx ids.

--- a/src/data/object_events/object_event_graphics.h
+++ b/src/data/object_events/object_event_graphics.h
@@ -189,6 +189,7 @@ const u16 gObjectEventPal_RSQuintyPlumpReflection[] = INCBIN_U16("graphics/objec
 
 const u16 gObjectEventPic_Silvio[] = INCBIN_U16("graphics/object_events/pics/people/silvio.4bpp");
 const u16 gObjectEventPic_Zubat[] = INCBIN_U16("graphics/object_events/pics/pokemon/zubat.4bpp");
+const u16 gObjectEventPic_Geodude[] = INCBIN_U16("graphics/object_events/pics/pokemon/geodude.4bpp");
 
 const u16 gFieldEffectObjectPic_ShadowSmall[] = INCBIN_U16("graphics/field_effects/pics/shadow_small.4bpp");
 const u16 gFieldEffectObjectPic_ShadowMedium[] = INCBIN_U16("graphics/field_effects/pics/shadow_medium.4bpp");

--- a/src/data/object_events/object_event_graphics_info.h
+++ b/src/data/object_events/object_event_graphics_info.h
@@ -2961,3 +2961,22 @@ const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Zubat = {
     .images = sPicTable_Zubat,
     .affineAnims = gDummySpriteAffineAnimTable,
 };
+
+const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Geodude = {
+    .tileTag = TAG_NONE,
+    .paletteTag = OBJ_EVENT_PAL_TAG_NPC_GREEN,
+    .reflectionPaletteTag = OBJ_EVENT_PAL_TAG_NONE,
+    .size = 256,
+    .width = 16,
+    .height = 32,
+    .paletteSlot = 4,
+    .shadowSize = SHADOW_SIZE_M,
+    .inanimate = FALSE,
+    .disableReflectionPaletteLoad = FALSE,
+    .tracks = TRACKS_FOOT,
+    .oam = &gObjectEventBaseOam_16x32,
+    .subspriteTables = gObjectEventSpriteOamTables_16x32,
+    .anims = sAnimTable_Standard,
+    .images = sPicTable_Geodude,
+    .affineAnims = gDummySpriteAffineAnimTable,
+};

--- a/src/data/object_events/object_event_graphics_info_pointers.h
+++ b/src/data/object_events/object_event_graphics_info_pointers.h
@@ -152,6 +152,7 @@ const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_DeoxysN;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_SSAnne;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Silvio;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Zubat;
+const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Geodude;
 
 const struct ObjectEventGraphicsInfo *const gObjectEventGraphicsInfoPointers[NUM_OBJ_EVENT_GFX] = {
     [OBJ_EVENT_GFX_RED_NORMAL]               = &gObjectEventGraphicsInfo_RedNormal,
@@ -306,6 +307,7 @@ const struct ObjectEventGraphicsInfo *const gObjectEventGraphicsInfoPointers[NUM
     [OBJ_EVENT_GFX_DEOXYS_A]                 = &gObjectEventGraphicsInfo_DeoxysA,
     [OBJ_EVENT_GFX_DEOXYS_N]                 = &gObjectEventGraphicsInfo_DeoxysN,
     [OBJ_EVENT_GFX_SS_ANNE]                  = &gObjectEventGraphicsInfo_SSAnne,
-    [OBJ_EVENT_GFX_SILVIO] = &gObjectEventGraphicsInfo_Silvio,
-    [OBJ_EVENT_GFX_ZUBAT]    = &gObjectEventGraphicsInfo_Zubat,
+    [OBJ_EVENT_GFX_SILVIO]                   = &gObjectEventGraphicsInfo_Silvio,
+    [OBJ_EVENT_GFX_ZUBAT]                    = &gObjectEventGraphicsInfo_Zubat,
+    [OBJ_EVENT_GFX_GEODUDE]                  = &gObjectEventGraphicsInfo_Geodude,
 };

--- a/src/data/object_events/object_event_pic_tables.h
+++ b/src/data/object_events/object_event_pic_tables.h
@@ -1776,3 +1776,15 @@ static const struct SpriteFrameImage sPicTable_Zubat[] = {
     overworld_frame(gObjectEventPic_Zubat, 2, 2, 7),
     overworld_frame(gObjectEventPic_Zubat, 2, 2, 8),
 };
+
+static const struct SpriteFrameImage sPicTable_Geodude[] = {
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 0),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 1),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 2),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 3),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 4),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 5),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 6),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 7),
+    overworld_frame(gObjectEventPic_Geodude, 2, 4, 8),
+};


### PR DESCRIPTION
## Summary
- add GEODUDE overworld graphics constant
- hook Geodude's graphics info and sprite tables

## Testing
- `make` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897d268acfc832e806956f40bb02084