### PR TITLE
Translate Mt. Moon NPC dialogue to Latin American Spanish

### DIFF
--- a/data/maps/MtMoon_1F/text.inc
+++ b/data/maps/MtMoon_1F/text.inc
@@ -1,95 +1,95 @@
 MtMoon_1F_Text_MarcosIntro::
-    .string "WHOA!\n"
-    .string "You shocked me!\l"
-    .string "…Oh, you're just a kid!$"
+    .string "¡Eh!\n"
+    .string "¡Me asustaste!\l"
+    .string "…Ah, ¡solo eres un niño!$"
 
 MtMoon_1F_Text_MarcosDefeat::
-    .string "Wow!\n"
-    .string "Shocked again!$"
+    .string "¡GUAU!\n"
+    .string "¡OTRA VEZ ME SORPRENDISTE!$"
 
 MtMoon_1F_Text_MarcosPostBattle::
-    .string "Kids like you shouldn't be\n"
-    .string "wandering around here in the dark.$"
+    .string "Los niños como tú no deberían\n"
+    .string "andar por aquí en la oscuridad.$"
 
 MtMoon_1F_Text_JoshIntro::
-    .string "Did you come to explore the cave,\n"
-    .string "too?$"
+    .string "¿También viniste a explorar la\n"
+    .string "cueva?$"
 
 MtMoon_1F_Text_JoshDefeat::
-    .string "Losing stinks!\n"
-    .string "It's so uncool.$"
+    .string "¡PERDER APESTA!\n"
+    .string "NO TIENE NADA DE GENIAL.$"
 
 MtMoon_1F_Text_JoshPostBattle::
-    .string "I came all the way down here to\n"
-    .string "show off to girls.$"
+    .string "Vine hasta aquí abajo para\n"
+    .string "presumir ante las chicas.$"
 
 MtMoon_1F_Text_MiriamIntro::
-    .string "Wow! It's way bigger in here than\n"
-    .string "I thought!$"
+    .string "¡Guau! ¡Es mucho más grande\n"
+    .string "de lo que pensaba!$"
 
 MtMoon_1F_Text_MiriamDefeat::
-    .string "Oh!\n"
-    .string "I lost it!$"
+    .string "¡OH!\n"
+    .string "¡PERDÍ!$"
 
 MtMoon_1F_Text_MiriamPostBattle::
-    .string "How do you get out of here?\n"
-    .string "It's so big, I may get lost.$"
+    .string "¿Cómo salgo de aquí?\n"
+    .string "Es tan grande que puedo perderme.$"
 
 MtMoon_1F_Text_JovanIntro::
-    .string "What!\n"
-    .string "Don't sneak up on me!$"
+    .string "¡¿Qué?!\n"
+    .string "¡No te acerques así!$"
 
 MtMoon_1F_Text_JovanDefeat::
-    .string "My POKéMON won't do!$"
+    .string "¡MIS POKÉMON NO PUEDEN MÁS!$"
 
 MtMoon_1F_Text_JovanPostBattle::
-    .string "I have to find stronger POKéMON.\n"
-    .string "Where might they be?$"
+    .string "Tengo que encontrar POKéMON más\n"
+    .string "fuertes. ¿Dónde estarán?$"
 
 MtMoon_1F_Text_IrisIntro::
-    .string "What?\n"
-    .string "I'm waiting for my friends to find\l"
-    .string "me here.$"
+    .string "¿Qué?\n"
+    .string "Estoy esperando a que mis amigos\l"
+    .string "me encuentren aquí.$"
 
 MtMoon_1F_Text_IrisDefeat::
-    .string "I lost?$"
+    .string "¿PERDÍ?$"
 
 MtMoon_1F_Text_IrisPostBattle::
-    .string "I came because I heard there are\n"
-    .string "some very rare fossils here.$"
+    .string "Vine porque oí que hay fósiles\n"
+    .string "muy raros aquí.$"
 
 MtMoon_1F_Text_KentIntro::
-    .string "Suspicious men are in the cave.\n"
-    .string "What about you?$"
+    .string "Hay hombres sospechosos en la\n"
+    .string "cueva. ¿Y tú?$"
 
 MtMoon_1F_Text_KentDefeat::
-    .string "You got me!$"
+    .string "¡ME VENCISTE!$"
 
 MtMoon_1F_Text_KentPostBattle::
-    .string "I saw them!\n"
-    .string "I'm sure they're from TEAM ROCKET!$"
+    .string "¡Los vi!\n"
+    .string "¡Estoy seguro de que son del TEAM ROCKET!$"
 
 MtMoon_1F_Text_RobbyIntro::
-    .string "You need to go through this cave\n"
-    .string "to get to CERULEAN CITY.$"
+    .string "Debes pasar por esta cueva\n"
+    .string "para llegar a CIUDAD CELESTE.$"
 
 MtMoon_1F_Text_RobbyDefeat::
-    .string "I lost.$"
+    .string "PERDÍ.$"
 
 MtMoon_1F_Text_RobbyPostBattle::
-    .string "ZUBAT is tough!\n"
-    .string "But if you can catch one, you'll\l"
-    .string "be able to count on it.$"
+    .string "¡ZUBAT es resistente!\n"
+    .string "Pero si logras atrapar uno, podrás\l"
+    .string "contar con él.$"
 
 MtMoon_1F_Text_ZubatIsABloodsucker::
-    .string "Beware!\n"
-    .string "ZUBAT is a bloodsucker!$"
+    .string "¡Cuidado!\n"
+    .string "¡ZUBAT es un chupasangre!$"
 
 MtMoon_1F_Text_BrockHelpsExcavateFossils::
-    .string "Hi, I'm excavating for fossils here\n"
-    .string "under MT. MOON.\p"
-    .string "Sometimes, BROCK of PEWTER GYM\n"
-    .string "lends me a hand.$"
+    .string "Hola, estoy excavando fósiles\n"
+    .string "aquí bajo el MONTE LUNAR.\p"
+    .string "A veces, BROCK del GIMNASIO\n"
+    .string "PLATEADO me echa una mano.$"
 
 MtMoon_1F_Text_Sign01::
     .string "{SHADOW DYNAMIC_COLOR4}MONTE LUNAR{SHADOW LIGHT_GRAY}\n"

--- a/data/maps/MtMoon_B2F/text.inc
+++ b/data/maps/MtMoon_B2F/text.inc
@@ -1,84 +1,84 @@
 MtMoon_B2F_Text_MiguelIntro::
-    .string "Hey, stop!\p"
-    .string "I found these fossils!\n"
-    .string "They're both mine!$"
+    .string "¡Oye, detente!\p"
+    .string "¡Encontré estos fósiles!\n"
+    .string "¡Los dos son míos!$"
 
 MtMoon_B2F_Text_MiguelDefeat::
-    .string "Okay!\n"
-    .string "I'll share!$"
+    .string "¡ESTÁ BIEN!\n"
+    .string "¡COMPARTIRÉ!$"
 
 MtMoon_B2F_Text_WellEachTakeAFossil::
-    .string "We'll each take a fossil!\n"
-    .string "No being greedy!$"
+    .string "¡Cada uno tomará un fósil!\n"
+    .string "¡Nada de avaricia!$"
 
 MtMoon_B2F_Text_ThenThisFossilIsMine::
-    .string "All right.\n"
-    .string "Then this fossil is mine!$"
+    .string "Muy bien.\n"
+    .string "¡Entonces este fósil es mío!$"
 
 MtMoon_B2F_Text_LabOnCinnabarRegeneratesFossils::
-    .string "Far away, on CINNABAR ISLAND,\n"
-    .string "there's a POKéMON LAB.\p"
-    .string "They do research on regenerating\n"
-    .string "fossils.$"
+    .string "Muy lejos, en la ISLA CANELA,\n"
+    .string "hay un LABORATORIO POKéMON.\p"
+    .string "Allí investigan cómo regenerar\n"
+    .string "fósiles.$"
 
 MtMoon_B2F_Text_Grunt1Intro::
-    .string "We, TEAM ROCKET, shall find the\n"
-    .string "fossils!\p"
-    .string "Reviving POKéMON from them will\n"
-    .string "earn us huge riches!$"
+    .string "Nosotros, el TEAM ROCKET,\n"
+    .string "¡encontraremos los fósiles!\p"
+    .string "Revivir POKéMON con ellos\n"
+    .string "nos dará enormes riquezas!$"
 
 MtMoon_B2F_Text_Grunt1Defeat::
-    .string "Urgh!\n"
-    .string "Now I'm mad!$"
+    .string "¡ARGH!\n"
+    .string "¡AHORA ESTOY FURIOSO!$"
 
 MtMoon_B2F_Text_Grunt1PostBattle::
-    .string "You made me mad!\n"
-    .string "TEAM ROCKET will blacklist you!$"
+    .string "¡Me hiciste enojar!\n"
+    .string "¡El TEAM ROCKET te pondrá en su lista negra!$"
 
 MtMoon_B2F_Text_Grunt2Intro::
-    .string "We, TEAM ROCKET, are POKéMON\n"
-    .string "gangsters!\l"
-    .string "We strike fear with our strength!$"
+    .string "Nosotros, el TEAM ROCKET, somos\n"
+    .string "¡gánsteres POKéMON!\l"
+    .string "¡Infundimos miedo con nuestra fuerza!$"
 
 MtMoon_B2F_Text_Grunt2Defeat::
-    .string "I blew it!$"
+    .string "¡LA ARRUINÉ!$"
 
 MtMoon_B2F_Text_Grunt2PostBattle::
-    .string "Darn it all!\n"
-    .string "My associates won't stand for this!$"
+    .string "¡Rayos!\n"
+    .string "¡Mis compañeros no soportarán esto!$"
 
 MtMoon_B2F_Text_Grunt3Intro::
-    .string "We're pulling a big job here!\n"
-    .string "Get lost, kid!$"
+    .string "¡Estamos haciendo un gran trabajo aquí!\n"
+    .string "¡Lárgate, niño!$"
 
 MtMoon_B2F_Text_Grunt3Defeat::
-    .string "So, you are good…$"
+    .string "ASÍ QUE ERES BUENO…$"
 
 MtMoon_B2F_Text_Grunt3PostBattle::
-    .string "If you find a fossil, give it to me\n"
-    .string "and scram!$"
+    .string "¡Si encuentras un fósil, dámelo\n"
+    .string "y lárgate!$"
 
 MtMoon_B2F_Text_Grunt4Intro::
-    .string "Little kids shouldn't be messing\n"
-    .string "around with grown-ups!\p"
-    .string "It could be bad news!$"
+    .string "¡Los niños no deberían meterse\n"
+    .string "con los adultos!\p"
+    .string "¡Podría acabar mal!$"
 
 MtMoon_B2F_Text_Grunt4Defeat::
-    .string "I'm steamed!$"
+    .string "¡ESTOY QUE ARDO!$"
 
 MtMoon_B2F_Text_Grunt4PostBattle::
-    .string "POKéMON lived here long before\n"
-    .string "people came.$"
+    .string "Los POKéMON vivían aquí mucho antes\n"
+    .string "de que llegara la gente.$"
 
 MtMoon_B2F_Text_YouWantDomeFossil::
-    .string "Do you want the DOME FOSSIL?$"
+    .string "¿Quieres el FÓSIL DOMO?$"
 
 MtMoon_B2F_Text_YouWantHelixFossil::
-    .string "Do you want the HELIX FOSSIL?$"
+    .string "¿Quieres el FÓSIL HÉLIX?$"
 
 MtMoon_B2F_Text_ObtainedHelixFossil::
-    .string "Obtained the HELIX FOSSIL!$"
+    .string "¡Obtuviste el FÓSIL HÉLIX!$"
 
 MtMoon_B2F_Text_ObtainedDomeFossil::
-    .string "Obtained the DOME FOSSIL!$"
+    .string "¡Obtuviste el FÓSIL DOMO!$"
 


### PR DESCRIPTION
## Summary
- localize Mt. Moon NPC interactions to neutral Latin American Spanish
- render all trainer defeat messages in uppercase for emphasis

## Testing
- `make -j4` *(fails: arm-none-eabi-as: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68982c2b3a68832ea74a0ed5549e6e7a