### PR TITLE
Add Sandshrew object event

### DIFF
--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -161,7 +161,8 @@
 #define OBJ_EVENT_GFX_ZUBAT    155
 #define OBJ_EVENT_GFX_GEODUDE 156
 #define OBJ_EVENT_GFX_NERD    157
-#define NUM_OBJ_EVENT_GFX      158
+#define OBJ_EVENT_GFX_SANDSHREW 158
+#define NUM_OBJ_EVENT_GFX      159
 
 // These are dynamic object gfx ids.
 // They correspond with the values of the VAR_OBJ_GFX_ID_X vars.

--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -414,3 +414,6 @@ $(OBJEVENTGFXDIR)/pokemon/zubat.4bpp: %.4bpp: %.png
 
 $(OBJEVENTGFXDIR)/pokemon/geodude.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/pokemon/sandshrew.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 2

--- a/src/data/object_events/object_event_graphics.h
+++ b/src/data/object_events/object_event_graphics.h
@@ -193,6 +193,7 @@ const u16 gObjectEventPic_Silvio[] = INCBIN_U16("graphics/object_events/pics/peo
 const u16 gObjectEventPic_Zubat[] = INCBIN_U16("graphics/object_events/pics/pokemon/zubat.4bpp");
 const u16 gObjectEventPic_Geodude[] = INCBIN_U16("graphics/object_events/pics/pokemon/geodude.4bpp");
 const u16 gObjectEventPic_Nerd[] = INCBIN_U16("graphics/object_events/pics/people/nerd.4bpp");
+const u16 gObjectEventPic_Sandshrew[] = INCBIN_U16("graphics/object_events/pics/pokemon/sandshrew.4bpp");
 
 const u16 gFieldEffectObjectPic_ShadowSmall[] = INCBIN_U16("graphics/field_effects/pics/shadow_small.4bpp");
 const u16 gFieldEffectObjectPic_ShadowMedium[] = INCBIN_U16("graphics/field_effects/pics/shadow_medium.4bpp");

--- a/src/data/object_events/object_event_graphics_info.h
+++ b/src/data/object_events/object_event_graphics_info.h
@@ -3037,3 +3037,22 @@ const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Nerd = {
     .images = sPicTable_Nerd,
     .affineAnims = gDummySpriteAffineAnimTable,
 };
+
+const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Sandshrew = {
+    .tileTag = TAG_NONE,
+    .paletteTag = OBJ_EVENT_PAL_TAG_NPC_BLUE,
+    .reflectionPaletteTag = OBJ_EVENT_PAL_TAG_NONE,
+    .size = 128,
+    .width = 16,
+    .height = 16,
+    .paletteSlot = 2,
+    .shadowSize = SHADOW_SIZE_M,
+    .inanimate = FALSE,
+    .disableReflectionPaletteLoad = FALSE,
+    .tracks = TRACKS_FOOT,
+    .oam = &gObjectEventBaseOam_16x16,
+    .subspriteTables = gObjectEventSpriteOamTables_16x16,
+    .anims = sAnimTable_Standard,
+    .images = sPicTable_Sandshrew,
+    .affineAnims = gDummySpriteAffineAnimTable,
+};

--- a/src/data/object_events/object_event_graphics_info_pointers.h
+++ b/src/data/object_events/object_event_graphics_info_pointers.h
@@ -156,6 +156,7 @@ const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Silvio;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Zubat;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Geodude;
 const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Nerd;
+const struct ObjectEventGraphicsInfo gObjectEventGraphicsInfo_Sandshrew;
 
 const struct ObjectEventGraphicsInfo *const gObjectEventGraphicsInfoPointers[NUM_OBJ_EVENT_GFX] = {
     [OBJ_EVENT_GFX_RED_NORMAL]               = &gObjectEventGraphicsInfo_RedNormal,
@@ -316,4 +317,5 @@ const struct ObjectEventGraphicsInfo *const gObjectEventGraphicsInfoPointers[NUM
     [OBJ_EVENT_GFX_ZUBAT]                    = &gObjectEventGraphicsInfo_Zubat,
     [OBJ_EVENT_GFX_GEODUDE]                  = &gObjectEventGraphicsInfo_Geodude,
     [OBJ_EVENT_GFX_NERD]                     = &gObjectEventGraphicsInfo_Nerd,
+    [OBJ_EVENT_GFX_SANDSHREW]                = &gObjectEventGraphicsInfo_Sandshrew,
 };

--- a/src/data/object_events/object_event_pic_tables.h
+++ b/src/data/object_events/object_event_pic_tables.h
@@ -1824,3 +1824,15 @@ static const struct SpriteFrameImage sPicTable_Nerd[] = {
     overworld_frame(gObjectEventPic_Nerd, 2, 4, 7),
     overworld_frame(gObjectEventPic_Nerd, 2, 4, 8),
 };
+
+static const struct SpriteFrameImage sPicTable_Sandshrew[] = {
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 0),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 1),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 2),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 3),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 4),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 5),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 6),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 7),
+    overworld_frame(gObjectEventPic_Sandshrew, 2, 2, 8),
+};


### PR DESCRIPTION
## Summary
- add Sandshrew overworld graphics and metadata analogous to Psyduck
- register Sandshrew spritesheet rule and constants

## Testing
- `make -j2` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a592c73e8832e9082a8b55f0278b2