### PR TITLE
Rename Cerulean sliding door to sliding_single

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -17,7 +17,8 @@
 #define METATILE_CeladonCity_DeptStoreDoor      0x294
 
 // gTileset_CeruleanCity
-#define METATILE_CeruleanCity_Door  0x298
+#define METATILE_CeruleanCity_Door         0x298
+#define METATILE_CeruleanCity_SlidingSingle  0x299
 
 // gTileset_CinnabarGym
 #define METATILE_CinnabarGym_Floor                  0x281

--- a/src/field_door.c
+++ b/src/field_door.c
@@ -258,6 +258,7 @@ static const struct DoorGraphics sDoorGraphics[] = {
     {METATILE_SaffronCity_Door,                            DOOR_SOUND_NORMAL,  DOOR_SIZE_1x1, sDoorAnimTiles_Saffron, sDoorAnimPalettes_Saffron},
     {METATILE_SaffronCity_SilphCoDoor,                     DOOR_SOUND_SLIDING, DOOR_SIZE_1x1, sDoorAnimTiles_SilphCo, sDoorAnimPalettes_SilphCo},
     {METATILE_CeruleanCity_Door,                           DOOR_SOUND_NORMAL,  DOOR_SIZE_1x1, sDoorAnimTiles_Cerulean, sDoorAnimPalettes_Cerulean},
+    {METATILE_CeruleanCity_SlidingSingle,                 DOOR_SOUND_SLIDING, DOOR_SIZE_1x1, sDoorAnimTiles_SlidingSingle, sDoorAnimPalettes_SlidingSingle},
     {METATILE_LavenderTown_Door,                           DOOR_SOUND_NORMAL,  DOOR_SIZE_1x1, sDoorAnimTiles_Lavender, sDoorAnimPalettes_Lavender},
     {METATILE_VermilionCity_Door,                          DOOR_SOUND_NORMAL,  DOOR_SIZE_1x1, sDoorAnimTiles_Vermilion, sDoorAnimPalettes_Vermilion},
 /*  Below was presumably intended for the door to the Pokemon Fan Club. The metatile is surrounded by metatiles for the fan club building.


### PR DESCRIPTION
## Summary
- rename Cerulean City custom sliding door metatile to SlidingSingle
- reuse the generic sliding_single door animation for the Cerulean tileset

## Testing
- `make build/firered/src/field_door.o` *(fails: requires jsonproc toolchain)*
- `arm-none-eabi-as --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9b051da0832eb7a4bafd476e9c88