### PR TITLE
Translate Route 4 NPC dialogue to Latin American Spanish

### DIFF
--- a/data/maps/Route4/text.inc
+++ b/data/maps/Route4/text.inc
@@ -1,79 +1,80 @@
 Route4_Text_TrippedOverGeodude::
-    .string "Ouch! I tripped over a rocky\n"
-    .string "POKéMON, GEODUDE!$"
+    .string "¡Ay! Tropecé con un POKéMON\n"
+    .string "rocoso, ¡GEODUDE!$"
 
 Route4_Text_CrissyIntro::
-    .string "I came to MT. MOON in search of\n"
-    .string "mushroom POKéMON.$"
+    .string "Vine al MT. MOON en busca de\n"
+    .string "POKéMON hongos.$"
 
 Route4_Text_CrissyDefeat::
-    .string "After all I did to catch them!$"
+    .string "¡Después de todo lo que hice para\n"
+    .string "atraparlos!$"
 
 Route4_Text_CrissyPostBattle::
-    .string "There might not be any more\n"
-    .string "mushrooms here.\p"
-    .string "I think I got them all.$"
+    .string "Puede que ya no haya más\n"
+    .string "hongos aquí.\p"
+    .string "Creo que ya los atrapé todos.$"
 
 Route4_Text_MtMoonEntrance::
     .string "MT. MOON\n"
-    .string "Tunnel Entrance$"
+    .string "ENTRADA DEL TÚNEL$"
 
 Route4_Text_RouteSign::
-    .string "ROUTE 4\n"
-    .string "MT. MOON - CERULEAN CITY$"
+    .string "RUTA 4\n"
+    .string "MT. MOON - CIUDAD CELESTE$"
 
 Text_MegaPunchTeach::
-    .string "A punch of roaring ferocity!\p"
-    .string "Packed with destructive power!\p"
-    .string "When the chips are down,\n"
-    .string "MEGA PUNCH is the ultimate attack!\l"
-    .string "You agree, yes?\p"
-    .string "Now!\n"
-    .string "Let me teach it to your POKéMON!$"
+    .string "¡Un puñetazo de ferocidad estruendosa!\p"
+    .string "¡Cargado con poder destructivo!\p"
+    .string "Cuando estés en apuros,\n"
+    .string "¡MEGA PUNCH es el ataque definitivo!\l"
+    .string "¿Estás de acuerdo?\p"
+    .string "¡Ahora!\n"
+    .string "¡Déjame enseñárselo a tu POKéMON!$"
 
 Text_MegaPunchDeclined::
-    .string "You'll be back when you understand\n"
-    .string "the worth of MEGA PUNCH.$"
+    .string "Volverás cuando entiendas\n"
+    .string "el valor de MEGA PUNCH.$"
 
 Text_MegaPunchWhichMon::
-    .string "Fine!\n"
-    .string "Which POKéMON will learn it?$"
+    .string "¡Bien!\n"
+    .string "¿Qué POKéMON lo aprenderá?$"
 
 Text_MegaPunchTaught::
-    .string "Now, we are comrades in the way of\n"
-    .string "punching!\p"
-    .string "You should go before you're seen\n"
-    .string "by the misguided fool who trains\l"
-    .string "only his silly kicking over there.$"
+    .string "¡Ahora somos camaradas en el arte del\n"
+    .string "puñetazo!\p"
+    .string "Deberías irte antes de que te vea\n"
+    .string "el tonto descarriado que solo entrena\l"
+    .string "sus patadas ridículas allá.$"
 
 Text_MegaKickTeach::
-    .string "A kick of brutal ferocity!\p"
-    .string "Packed with destructive power!\p"
-    .string "When you get right down to it,\n"
-    .string "MEGA KICK is the ultimate attack!\l"
-    .string "Don't you agree?\p"
-    .string "Okay!\n"
-    .string "I'll teach it to your POKéMON!$"
+    .string "¡Una patada de ferocidad brutal!\p"
+    .string "¡Cargada con poder destructivo!\p"
+    .string "A fin de cuentas,\n"
+    .string "¡MEGA KICK es el ataque definitivo!\l"
+    .string "¿No lo crees?\p"
+    .string "¡Bien!\n"
+    .string "¡Se la enseñaré a tu POKéMON!$"
 
 Text_MegaKickDeclined::
-    .string "You'll come crawling back when you\n"
-    .string "realize the value of MEGA KICK.$"
+    .string "Volverás arrepentido cuando\n"
+    .string "entiendas el valor de MEGA KICK.$"
 
 Text_MegaKickWhichMon::
-    .string "All right!\n"
-    .string "Which POKéMON wants to learn it?$"
+    .string "¡Muy bien!\n"
+    .string "¿Qué POKéMON quiere aprenderlo?$"
 
 Text_MegaKickTaught::
-    .string "Now, we are soul mates in the way\n"
-    .string "of kicking!\p"
-    .string "You should run before you're seen\n"
-    .string "by the deluded nitwit who trains\l"
-    .string "only simple punching over there.$"
+    .string "¡Ahora somos almas gemelas en el arte\n"
+    .string "de la patada!\p"
+    .string "Deberías correr antes de que te vea\n"
+    .string "el iluso despistado que solo entrena\l"
+    .string "sus simples puñetazos allá.$"
 
 Route4_Text_PeopleLikeAndRespectBrock::
-    .string "Oh, wow, that's the BOULDERBADGE!\n"
-    .string "You got it from BROCK, didn't you?\p"
-    .string "BROCK is cool. He's not just tough.\n"
-    .string "People like and respect him.\p"
-    .string "I want to become a GYM LEADER\n"
-    .string "like him.$"
+    .string "¡Oh, vaya, esa es la MEDALLA ROCA!\n"
+    .string "La obtuviste de BROCK, ¿verdad?\p"
+    .string "BROCK es genial. No solo es fuerte.\n"
+    .string "La gente lo quiere y lo respeta.\p"
+    .string "Quiero convertirme en un LÍDER de\n"
+    .string "GIMNASIO como él.$"


### PR DESCRIPTION
## Summary
- Translate Route 4 NPC and sign text into neutral Latin American Spanish
- Localize Mega Punch and Mega Kick tutor dialogues
- Localize Brock fan's admiration lines and area signs

## Testing
- `make -j2` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d3dcb93f0832ea073690651c14a9d