### PR TITLE
Add Pallet Town tileset animation

### DIFF
--- a/include/tileset_anims.h
+++ b/include/tileset_anims.h
@@ -14,6 +14,7 @@ void InitTilesetAnim_CeladonGym(void);
 void InitTilesetAnim_SilphCo(void);
 void InitTilesetAnim_MtEmber(void);
 void InitTilesetAnim_Cave(void);
+void InitTilesetAnim_PalletTown(void);
 void InitTilesetAnim_LavenderTown(void);
 
 #endif // GUARD_TILESET_ANIMS_H

--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -17,7 +17,7 @@ const struct Tileset gTileset_PalletTown =
     .palettes = gTilesetPalettes_PalletTown,
     .metatiles = gMetatiles_PalletTown,
     .metatileAttributes = gMetatileAttributes_PalletTown,
-    .callback = NULL,
+    .callback = InitTilesetAnim_PalletTown,
 };
 
 const struct Tileset gTileset_ViridianCity =

--- a/src/tileset_anims.c
+++ b/src/tileset_anims.c
@@ -201,6 +201,16 @@ static const u16 *const sTilesetAnims_LavenderTown_Torii[] = {
     sTilesetAnims_LavenderTown_Torii_Frame5
 };
 
+static const u16 sTilesetAnims_PalletTown_Mailbox_Frame0[] = INCBIN_U16("data/tilesets/secondary/pallet_town/anim/mailbox/0.4bpp");
+static const u16 sTilesetAnims_PalletTown_Mailbox_Frame1[] = INCBIN_U16("data/tilesets/secondary/pallet_town/anim/mailbox/1.4bpp");
+static const u16 sTilesetAnims_PalletTown_Mailbox_Frame2[] = INCBIN_U16("data/tilesets/secondary/pallet_town/anim/mailbox/2.4bpp");
+
+static const u16 *const sTilesetAnims_PalletTown_Mailbox[] = {
+    sTilesetAnims_PalletTown_Mailbox_Frame0,
+    sTilesetAnims_PalletTown_Mailbox_Frame1,
+    sTilesetAnims_PalletTown_Mailbox_Frame2,
+};
+
 static const u16 sTilesetAnims_VermilionGym_MotorizedDoor_Frame0[] = INCBIN_U16("data/tilesets/secondary/vermilion_gym/anim/motorizeddoor/0.4bpp");
 static const u16 sTilesetAnims_VermilionGym_MotorizedDoor_Frame1[] = INCBIN_U16("data/tilesets/secondary/vermilion_gym/anim/motorizeddoor/1.4bpp");
 
@@ -498,6 +508,24 @@ void InitTilesetAnim_LavenderTown(void)
     sSecondaryTilesetAnimCounter = 0;
     sSecondaryTilesetAnimCounterMax = 256;
     sSecondaryTilesetAnimCallback = TilesetAnim_LavenderTown;
+}
+
+static void QueueAnimTiles_PalletTown_Mailbox(u16 timer)
+{
+    AppendTilesetAnimToBuffer(sTilesetAnims_PalletTown_Mailbox[timer % ARRAY_COUNT(sTilesetAnims_PalletTown_Mailbox)], (u16 *)(BG_VRAM + TILE_OFFSET_4BPP(896)), 2 * TILE_SIZE_4BPP);
+}
+
+static void TilesetAnim_PalletTown(u16 timer)
+{
+    if (timer % 16 == 0)
+        QueueAnimTiles_PalletTown_Mailbox(timer / 16);
+}
+
+void InitTilesetAnim_PalletTown(void)
+{
+    sSecondaryTilesetAnimCounter = 0;
+    sSecondaryTilesetAnimCounterMax = 256;
+    sSecondaryTilesetAnimCallback = TilesetAnim_PalletTown;
 }
 
 


### PR DESCRIPTION
## Summary
- animate Pallet Town tileset using 3-frame mailbox tile
- set Pallet Town tileset callback to the new animation
- remove placeholder mailbox frames so they can be added manually

## Testing
- `make -j2` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e59bffb4c832e9881ccc7982d7907