### PR TITLE
Add Viridian City flower tile animation

### DIFF
--- a/include/tileset_anims.h
+++ b/include/tileset_anims.h
@@ -15,6 +15,7 @@ void InitTilesetAnim_SilphCo(void);
 void InitTilesetAnim_MtEmber(void);
 void InitTilesetAnim_Cave(void);
 void InitTilesetAnim_PalletTown(void);
+void InitTilesetAnim_ViridianCity(void);
 void InitTilesetAnim_LavenderTown(void);
 
 #endif // GUARD_TILESET_ANIMS_H

--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -28,7 +28,7 @@ const struct Tileset gTileset_ViridianCity =
     .palettes = gTilesetPalettes_ViridianCity,
     .metatiles = gMetatiles_ViridianCity,
     .metatileAttributes = gMetatileAttributes_ViridianCity,
-    .callback = NULL,
+    .callback = InitTilesetAnim_ViridianCity,
 };
 
 const struct Tileset gTileset_PewterCity =

--- a/src/tileset_anims.c
+++ b/src/tileset_anims.c
@@ -211,6 +211,14 @@ static const u16 *const sTilesetAnims_PalletTown_Flower[] = {
     sTilesetAnims_PalletTown_Flower_Frame2,
 };
 
+static const u16 sTilesetAnims_ViridianCity_Flower_Frame0[] = INCBIN_U16("data/tilesets/secondary/viridian_city/anim/flower/0.4bpp");
+static const u16 sTilesetAnims_ViridianCity_Flower_Frame1[] = INCBIN_U16("data/tilesets/secondary/viridian_city/anim/flower/1.4bpp");
+
+static const u16 *const sTilesetAnims_ViridianCity_Flower[] = {
+    sTilesetAnims_ViridianCity_Flower_Frame0,
+    sTilesetAnims_ViridianCity_Flower_Frame1,
+};
+
 static const u16 sTilesetAnims_VermilionGym_MotorizedDoor_Frame0[] = INCBIN_U16("data/tilesets/secondary/vermilion_gym/anim/motorizeddoor/0.4bpp");
 static const u16 sTilesetAnims_VermilionGym_MotorizedDoor_Frame1[] = INCBIN_U16("data/tilesets/secondary/vermilion_gym/anim/motorizeddoor/1.4bpp");
 
@@ -526,6 +534,24 @@ void InitTilesetAnim_PalletTown(void)
     sSecondaryTilesetAnimCounter = 0;
     sSecondaryTilesetAnimCounterMax = 256;
     sSecondaryTilesetAnimCallback = TilesetAnim_PalletTown;
+}
+
+static void QueueAnimTiles_ViridianCity_Flower(u16 timer)
+{
+    AppendTilesetAnimToBuffer(sTilesetAnims_ViridianCity_Flower[timer % ARRAY_COUNT(sTilesetAnims_ViridianCity_Flower)], (u16 *)(BG_VRAM + TILE_OFFSET_4BPP(966)), 2 * TILE_SIZE_4BPP);
+}
+
+static void TilesetAnim_ViridianCity(u16 timer)
+{
+    if (timer % 16 == 0)
+        QueueAnimTiles_ViridianCity_Flower(timer / 16);
+}
+
+void InitTilesetAnim_ViridianCity(void)
+{
+    sSecondaryTilesetAnimCounter = 0;
+    sSecondaryTilesetAnimCounterMax = 256;
+    sSecondaryTilesetAnimCallback = TilesetAnim_ViridianCity;
 }
 
 


### PR DESCRIPTION
## Summary
- add two-frame flower animation for Viridian City tileset
- hook Viridian City tileset to animation initializer

## Testing
- `make build/firered/src/tileset_anims.o` *(fails: Failed to open "data/tilesets/secondary/viridian_city/anim/flower/0.png")*


------
https://chatgpt.com/codex/tasks/task_e_68a3c28ae37c832e9c69ecc245af0cdf