### PR TITLE
Add new Team Rocket grunt trainer

### DIFF
--- a/include/constants/opponents.h
+++ b/include/constants/opponents.h
@@ -756,11 +756,12 @@
 #define TRAINER_HIKER_GUSTAVO                    750
 #define TRAINER_LEADER_BROCK2                    751
 #define TRAINER_SILVIO                           752
-// NOTE: Because each Trainer uses a flag to determine when they are defeated, there is 
+#define TRAINER_TEAM_ROCKET_GRUNT_52             753
+// NOTE: Because each Trainer uses a flag to determine when they are defeated, there is
 //       only space for 25 additional trainers before trainer flag space overflows.
 //       MAX_TRAINERS_COUNT can be increased but will take up additional saveblock space
 
-#define NUM_TRAINERS                             752
+#define NUM_TRAINERS                             753
 #define MAX_TRAINERS_COUNT                       769
 
 #endif  // GUARD_CONSTANTS_OPPONENTS_H

--- a/src/data/trainer_parties.h
+++ b/src/data/trainer_parties.h
@@ -8066,6 +8066,24 @@ static const struct TrainerMonNoItemDefaultMoves sParty_TeamRocketGrunt51[] = {
     },
 };
 
+static const struct TrainerMonNoItemDefaultMoves sParty_TeamRocketGrunt52[] = {
+    {
+        .iv = 0,
+        .lvl = 28,
+        .species = SPECIES_GOLBAT,
+    },
+    {
+        .iv = 0,
+        .lvl = 28,
+        .species = SPECIES_DROWZEE,
+    },
+    {
+        .iv = 0,
+        .lvl = 28,
+        .species = SPECIES_HYPNO,
+    },
+};
+
 static const struct TrainerMonNoItemDefaultMoves sParty_BirdKeeperMilo[] = {
     {
         .iv = 0,

--- a/src/data/trainers.h
+++ b/src/data/trainers.h
@@ -5718,6 +5718,16 @@ const struct Trainer gTrainers[] = {
         .aiFlags = AI_SCRIPT_CHECK_BAD_MOVE,
         .party = NO_ITEM_DEFAULT_MOVES(sParty_TeamRocketGrunt51),
     },
+    [TRAINER_TEAM_ROCKET_GRUNT_52] = {
+        .trainerClass = TRAINER_CLASS_TEAM_ROCKET,
+        .encounterMusic_gender = TRAINER_ENCOUNTER_MUSIC_AQUA,
+        .trainerPic = TRAINER_PIC_ROCKET_GRUNT_M,
+        .trainerName = _("GRUNT"),
+        .items = {},
+        .doubleBattle = FALSE,
+        .aiFlags = AI_SCRIPT_CHECK_BAD_MOVE,
+        .party = NO_ITEM_DEFAULT_MOVES(sParty_TeamRocketGrunt52),
+    },
     [TRAINER_BIRD_KEEPER_MILO] = {
         .trainerClass = TRAINER_CLASS_BIRD_KEEPER,
         .encounterMusic_gender = TRAINER_ENCOUNTER_MUSIC_COOL,


### PR DESCRIPTION
## Summary
- add new TEAM_ROCKET_GRUNT_52 constant and update trainer count
- define trainer data and party mirroring grunt 38

## Testing
- `make tools`
- `make -j2` *(fails: tools/agbcc/bin/agbcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a527810c94832e97d450b0b469faa6